### PR TITLE
Refactoring all tests to be more modular

### DIFF
--- a/enf/auth_test.go
+++ b/enf/auth_test.go
@@ -2,53 +2,49 @@ package enf
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"net/http"
-	"reflect"
-	"strings"
 	"testing"
 )
 
 func TestAuthService_Authenticate(t *testing.T) {
-	client, mux, teardown := setup()
-	defer teardown()
+	path := "/api/xcr/v2/xauth"
 
-	input := &AuthRequest{
+	requestBody := &AuthRequest{
 		Username: String("user"),
 		Password: String("pass"),
 	}
 
-	wantAcceptHeaders := []string{mediaTypeJson}
-	wantContentTypeHeaders := []string{mediaTypeJson}
-	mux.HandleFunc("/api/xcr/v2/xauth", func(w http.ResponseWriter, r *http.Request) {
-		v := new(AuthRequest)
-		_ = json.NewDecoder(r.Body).Decode(v)
+	responseBodyMock := `{
+		"data": [
+			{
+				"username":"user",
+				"token":"12345678",
+				"user_id":1
+			}
+		],
+		"page": {
 
-		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
-		testHeader(t, r, "Content-Type", strings.Join(wantContentTypeHeaders, ", "))
-		if !reflect.DeepEqual(v, input) {
-			t.Errorf("Request body = %+v, want %+v", v, input)
-		}
+			}
+		}`
 
-		fmt.Fprint(w, `{"data":[{"username":"user",
-                                "token":"12345678",
-                                "user_id":1}],
-                        "page":{}}`)
-	})
-
-	auth, _, err := client.Auth.Authenticate(context.Background(), input)
-	if err != nil {
-		t.Errorf("Auth.Authenticate returned error: %v", err)
-	}
-
-	want := &Credentials{
+	expected := &Credentials{
 		Username: String("user"),
 		Token:    String("12345678"),
 		UserID:   Int64(1),
 	}
-	if !reflect.DeepEqual(auth, want) {
-		t.Errorf("Auth.Authenticate returned %+v, want %+v", auth, want)
+
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		return client.Auth.Authenticate(context.Background(), requestBody)
 	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      requestBody,
+		ResponseBodyMock: responseBodyMock,
+		Expected:         expected,
+		Method:           method,
+		T:                t,
+	}
+
+	postTest(testParams)
 }

--- a/enf/domain_test.go
+++ b/enf/domain_test.go
@@ -2,22 +2,14 @@ package enf
 
 import (
 	"context"
-	"fmt"
 	"net/http"
-	"reflect"
-	"strings"
 	"testing"
 )
 
 func TestDomainService_ListDomains(t *testing.T) {
-	client, mux, teardown := setup()
-	defer teardown()
+	path := "/api/xcr/v2/domains"
 
-	wantAcceptHeaders := []string{mediaTypeJson}
-	mux.HandleFunc("/api/xcr/v2/domains", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
-		fmt.Fprint(w, `{
+	responseBodyMock := `{
 		"data": [
 			{
 				"network": "N/n0",
@@ -36,15 +28,9 @@ func TestDomainService_ListDomains(t *testing.T) {
 			"prev": -1
 		}
 	}
-			`)
-	})
+			`
 
-	domains, _, err := client.Domains.ListDomains(context.Background())
-	if err != nil {
-		t.Errorf("Domains.ListDomains returned error: %v", err)
-	}
-
-	want := []*Domain{
+	expected := []*Domain{
 		{
 			Name:    String("test.domain.1"),
 			Network: String("N/n0"),
@@ -56,179 +42,188 @@ func TestDomainService_ListDomains(t *testing.T) {
 			Status:  String("ACTIVE"),
 		},
 	}
-	if !reflect.DeepEqual(domains, want) {
-		t.Errorf("Domains.ListDomains returned %+v, want %+v", domains, want)
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		return client.Domains.ListDomains(context.Background())
 	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      struct{}{},
+		ResponseBodyMock: responseBodyMock,
+		Expected:         expected,
+		Method:           method,
+		T:                t,
+	}
+
+	getTest(testParams)
 }
 
 func TestDomainService_GetDomain(t *testing.T) {
-	client, mux, teardown := setup()
-	defer teardown()
+	path := "/api/xcr/v2/domains/N/n0"
 
-	wantAcceptHeaders := []string{mediaTypeJson}
-	mux.HandleFunc("/api/xcr/v2/domains/N/n0", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
-		fmt.Fprint(w, `{
-			"data": [
-				{
-					"network": "N/n0",
-					"name": "test.domain.1",
-					"status": "ACTIVE"
-				}
-			],
-			"page": {
-				"curr": -1,
-				"next": -1,
-				"prev": -1
+	responseBodyMock := `{
+		"data": [
+			{
+				"network": "N/n0",
+				"name": "test.domain.1",
+				"status": "ACTIVE"
 			}
+		],
+		"page": {
+			"curr": -1,
+			"next": -1,
+			"prev": -1
 		}
-				`)
-	})
-
-	domain, _, err := client.Domains.GetDomain(context.Background(), "N/n0")
-	if err != nil {
-		t.Errorf("Domains.GetDomain returned error: %v", err)
 	}
+			`
 
-	want := &Domain{
+	expected := &Domain{
 		Name:    String("test.domain.1"),
 		Network: String("N/n0"),
 		Status:  String("ACTIVE"),
 	}
-	if !reflect.DeepEqual(domain, want) {
-		t.Errorf("Domains.GetDomain returned %+v, want %+v", domain, want)
+
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		return client.Domains.GetDomain(context.Background(), "N/n0")
 	}
 
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      struct{}{},
+		ResponseBodyMock: responseBodyMock,
+		Expected:         expected,
+		Method:           method,
+		T:                t,
+	}
+
+	getTest(testParams)
 }
 
 func TestDomainService_CreateDomain(t *testing.T) {
-	client, mux, teardown := setup()
-	defer teardown()
+	path := "/api/xcr/v2/domains"
 
-	wantAcceptHeaders := []string{mediaTypeJson}
-	mux.HandleFunc("/api/xcr/v2/domains", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
-		fmt.Fprint(w, `{
-			"data": [
-				{
-					"network": "N/n0",
-					"name": "test.domain.1",
-					"status": "READY"
-				}
-			],
-			"page": {
-				"curr": -1,
-				"next": -1,
-				"prev": -1
-			}
-			}`)
-	})
-
-	newDomainRequest := &DomainRequest{
+	requestBody := &DomainRequest{
 		Name:       String("test.domain.1"),
 		Type:       String("CUSTOMER_SOURCE"),
 		AdminName:  String("tester"),
 		AdminEmail: String("tester@test.com"),
 	}
-	newDomain, _, err := client.Domains.CreateDomain(context.Background(), newDomainRequest)
-	if err != nil {
-		t.Errorf("Domains.CreateDomain returned error: %v", err)
-	}
 
-	want := &Domain{
+	responseBodyMock := `{
+		"data": [
+			{
+				"network": "N/n0",
+				"name": "test.domain.1",
+				"status": "READY"
+			}
+		],
+		"page": {
+			"curr": -1,
+			"next": -1,
+			"prev": -1
+		}
+		}`
+
+	expected := &Domain{
 		Name:    String("test.domain.1"),
 		Network: String("N/n0"),
 		Status:  String("READY"),
 	}
 
-	if !reflect.DeepEqual(newDomain, want) {
-		t.Errorf("Domains.CreateDomain returned %+v, want %+v", newDomain, want)
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		return client.Domains.CreateDomain(context.Background(), requestBody)
 	}
 
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      requestBody,
+		ResponseBodyMock: responseBodyMock,
+		Expected:         expected,
+		Method:           method,
+		T:                t,
+	}
+
+	postTest(testParams)
 }
 
 func TestDomainService_ActivateDomain(t *testing.T) {
-	client, mux, teardown := setup()
-	defer teardown()
+	path := "/api/xcr/v2/domains/N/n0/status"
 
-	wantAcceptHeaders := []string{mediaTypeJson}
-	wantContentTypeHeaders := []string{mediaTypeJson}
-	mux.HandleFunc("/api/xcr/v2/domains/N/n0/status", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "PUT")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
-		testHeader(t, r, "Content-Type", strings.Join(wantContentTypeHeaders, ", "))
-		fmt.Fprint(w, `{
-			"data": [
-				{
-					"network": "N/n0",
-					"name": "test.domain.1",
-					"status": "ACTIVE"
-				}
-			],
-			"page": {
-				"curr": -1,
-				"next": -1,
-				"prev": -1
+	responseBodyMock := `{
+		"data": [
+			{
+				"network": "N/n0",
+				"name": "test.domain.1",
+				"status": "ACTIVE"
 			}
+		],
+		"page": {
+			"curr": -1,
+			"next": -1,
+			"prev": -1
 		}
-				`)
-	})
-
-	activatedDomain, _, err := client.Domains.ActivateDomain(context.Background(), "N/n0")
-	if err != nil {
-		t.Errorf("Domains.ActivateDomain returned error: %v", err)
 	}
+			`
 
-	want := &Domain{
+	expected := &Domain{
 		Name:    String("test.domain.1"),
 		Network: String("N/n0"),
 		Status:  String("ACTIVE"),
 	}
-	if !reflect.DeepEqual(activatedDomain, want) {
-		t.Errorf("Domains.ActivateDomain returned %+v, want %+v", activatedDomain, want)
+
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		return client.Domains.ActivateDomain(context.Background(), "N/n0")
 	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      struct{}{},
+		ResponseBodyMock: responseBodyMock,
+		Expected:         expected,
+		Method:           method,
+		T:                t,
+	}
+
+	putTest(testParams)
 }
 
 func TestDomainService_DeactivateDomain(t *testing.T) {
-	client, mux, teardown := setup()
-	defer teardown()
+	path := "/api/xcr/v2/domains/N/n0/status"
 
-	wantAcceptHeaders := []string{mediaTypeJson}
-	wantContentTypeHeaders := []string{mediaTypeJson}
-	mux.HandleFunc("/api/xcr/v2/domains/N/n0/status", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "PUT")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
-		testHeader(t, r, "Content-Type", strings.Join(wantContentTypeHeaders, ", "))
-		fmt.Fprint(w, `{
-			"data": [
-				{
-					"network": "N/n0",
-					"name": "test.domain.1",
-					"status": "READY"
-				}
-			],
-			"page": {
-				"curr": -1,
-				"next": -1,
-				"prev": -1
+	responseBodyMock := `{
+		"data": [
+			{
+				"network": "N/n0",
+				"name": "test.domain.1",
+				"status": "READY"
 			}
+		],
+		"page": {
+			"curr": -1,
+			"next": -1,
+			"prev": -1
 		}
-				`)
-	})
-
-	deactivatedDomain, _, err := client.Domains.DeactivateDomain(context.Background(), "N/n0")
-	if err != nil {
-		t.Errorf("Domains.DeactivateDomain returned error: %v", err)
 	}
+			`
 
-	want := &Domain{
+	expected := &Domain{
 		Name:    String("test.domain.1"),
 		Network: String("N/n0"),
 		Status:  String("READY"),
 	}
-	if !reflect.DeepEqual(deactivatedDomain, want) {
-		t.Errorf("Domains.DeactivateDomain returned %+v, want %+v", deactivatedDomain, want)
+
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		return client.Domains.DeactivateDomain(context.Background(), "N/n0")
 	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      struct{}{},
+		ResponseBodyMock: responseBodyMock,
+		Expected:         expected,
+		Method:           method,
+		T:                t,
+	}
+
+	putTest(testParams)
 }

--- a/enf/enf.go
+++ b/enf/enf.go
@@ -21,11 +21,13 @@ const (
 	headerToken       = "Authorization"
 	headerTokenFormat = "Bearer %s"
 
-	mediaTypeJson = "application/json"
+	mediaTypeJSON = "application/json"
 )
 
 var (
-	defaultUserAgent = fmt.Sprintf("go-enf/%s (+%s; %s)", projectVersion, projectURL, runtime.Version())
+	defaultUserAgent       = fmt.Sprintf("go-enf/%s (+%s; %s)", projectVersion, projectURL, runtime.Version())
+	wantAcceptHeaders      = []string{mediaTypeJSON}
+	wantContentTypeHeaders = []string{mediaTypeJSON}
 )
 
 // Client represents a wrapper for the HTTP client that communicates with the API.

--- a/enf/enf_test.go
+++ b/enf/enf_test.go
@@ -1,10 +1,36 @@
 package enf
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
+	"strings"
 	"testing"
 )
+
+type TestParams struct {
+
+	// Path is the API path.
+	Path string
+
+	// RequestBody is the body of the request. For GET/DELETE requests,
+	// RequestBody should be an empty struct.
+	RequestBody interface{}
+
+	// ResponseBodyMock is the body of the response from the mock server
+	// for this test.
+	ResponseBodyMock string
+
+	// Expected is the expected result from calling Method.
+	Expected interface{}
+
+	// Method is the method being tested.
+	Method func(*Client) (interface{}, *http.Response, error)
+
+	// T is the testing type used for managing test state and logging.
+	T *testing.T
+}
 
 // setup sets up a test HTTP server along with an enf.Client that is
 // configured to talk to that test server. Test should register
@@ -16,6 +42,77 @@ func setup() (client *Client, mux *http.ServeMux, teardown func()) {
 	client, _ = NewClient(server.URL, nil)
 
 	return client, mux, server.Close
+}
+
+// Each of the following four functions provides an easy, abstracted
+// way to test an API method. For examples of using these functions,
+// look at any of the testing files.
+func getTest(testingParameters *TestParams) interface{} {
+	return checkMethod("GET", testingParameters)
+}
+
+func postTest(testingParameters *TestParams) interface{} {
+	return checkMethod("POST", testingParameters)
+}
+
+func putTest(testingParameters *TestParams) interface{} {
+	return checkMethod("PUT", testingParameters)
+}
+
+func deleteTest(testingParameters *TestParams) interface{} {
+	return checkMethod("DELETE", testingParameters)
+}
+
+// checkMethod does the hard work for verifying that the method being
+// tested gives the right output. checkMethod sets up the dependencies,
+// mocks out the path, and checks for equality with the expected and actual responses.
+func checkMethod(methodType string, testingParameters *TestParams) interface{} {
+	client, mux, teardown := setup()
+	defer teardown()
+
+	mockPath(testingParameters, methodType, mux)
+
+	result, _, err := testingParameters.Method(client)
+	if err != nil {
+		testingParameters.T.Error(err)
+	}
+
+	if !reflect.DeepEqual(result, testingParameters.Expected) {
+		testingParameters.T.Errorf("Method returned %+v, want %+v", result, testingParameters.Expected)
+	}
+
+	return result
+}
+
+// mockPath creates a mock response on a mux for a specific path included in the testing
+// parameters.
+func mockPath(testingParameters *TestParams, methodType string, mux *http.ServeMux) {
+	mux.HandleFunc(testingParameters.Path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(testingParameters.T, r, methodType)
+		testHeaders(testingParameters.T, methodType, mux, r)
+		fmt.Fprint(w, testingParameters.ResponseBodyMock)
+	})
+}
+
+// testHeaders verifies that the headers are appropriate for the given request.
+func testHeaders(t *testing.T, methodType string, mux *http.ServeMux, r *http.Request) {
+	switch methodType {
+	case "GET":
+		testGetHeaders(t, r)
+	case "POST":
+		testPostPutHeaders(t, r)
+	case "PUT":
+		testPostPutHeaders(t, r)
+	}
+}
+
+func testGetHeaders(t *testing.T, r *http.Request) {
+	testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
+}
+
+func testPostPutHeaders(t *testing.T, r *http.Request) {
+	testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
+	testHeader(t, r, "Content-Type", strings.Join(wantContentTypeHeaders, ", "))
 }
 
 func testMethod(t *testing.T, r *http.Request, want string) {

--- a/enf/firewall_test.go
+++ b/enf/firewall_test.go
@@ -2,114 +2,125 @@ package enf
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"net/http"
-	"reflect"
-	"strings"
 	"testing"
 )
 
 func TestFirewallService_ListRules(t *testing.T) {
-	client, mux, teardown := setup()
-	defer teardown()
+	path := "/api/xfw/v1/N/rule"
 
-	wantAcceptHeaders := []string{mediaTypeJson}
-	mux.HandleFunc("/api/xfw/v1/N/rule", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
-		fmt.Fprint(w, `[{"id":"00000000-0000-4000-2000-000000000000"},
-                        {"id":"00000000-0000-4000-2000-000000000001"}]`)
-	})
+	responseBodyMock := `[
+		{
+			"id": "00000000-0000-4000-2000-000000000000"
+		},
+		{
+			"id":"00000000-0000-4000-2000-000000000001"
+		}
+	]`
 
-	rules, _, err := client.Firewall.ListRules(context.Background(), "N")
-	if err != nil {
-		t.Errorf("Firewall.ListRules returned error: %v", err)
-	}
-
-	want := []*FirewallRule{
+	expected := []*FirewallRule{
 		{ID: String("00000000-0000-4000-2000-000000000000")},
 		{ID: String("00000000-0000-4000-2000-000000000001")},
 	}
-	if !reflect.DeepEqual(rules, want) {
-		t.Errorf("Firewall.ListRules returned %+v, want %+v", rules, want)
+
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		return client.Firewall.ListRules(context.Background(), "N")
 	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      struct{}{},
+		ResponseBodyMock: responseBodyMock,
+		Expected:         expected,
+		Method:           method,
+		T:                t,
+	}
+
+	getTest(testParams)
 }
 
 func TestFirewallService_GetRule(t *testing.T) {
-	client, mux, teardown := setup()
-	defer teardown()
+	path := "/api/xfw/v1/N/rule"
 
-	wantAcceptHeaders := []string{mediaTypeJson}
-	mux.HandleFunc("/api/xfw/v1/N/rule", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
-		fmt.Fprint(w, `[{"id":"00000000-0000-4000-2000-000000000000"},
-                        {"id":"00000000-0000-4000-2000-000000000001"}]`)
-	})
+	responseBodyMock := `[
+		{
+			"id":"00000000-0000-4000-2000-000000000000"
+		},
+		{
+			"id":"00000000-0000-4000-2000-000000000001"
+		}
+	]`
 
-	rule, _, err := client.Firewall.GetRule(context.Background(), "N", "00000000-0000-4000-2000-000000000001")
-	if err != nil {
-		t.Errorf("Firewall.GetRule returned error: %v", err)
-	}
-
-	want := &FirewallRule{
+	expected := &FirewallRule{
 		ID: String("00000000-0000-4000-2000-000000000001"),
 	}
-	if !reflect.DeepEqual(rule, want) {
-		t.Errorf("Firewall.GetRule returned %+v, want %+v", rule, want)
+
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		return client.Firewall.GetRule(context.Background(), "N", "00000000-0000-4000-2000-000000000001")
 	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      struct{}{},
+		ResponseBodyMock: responseBodyMock,
+		Expected:         expected,
+		Method:           method,
+		T:                t,
+	}
+
+	getTest(testParams)
 }
 
 func TestFirewallService_CreateRule(t *testing.T) {
-	client, mux, teardown := setup()
-	defer teardown()
+	path := "/api/xfw/v1/N/rule"
 
-	input := &FirewallRuleRequest{
+	requestBody := &FirewallRuleRequest{
 		Priority:  Int(1),
 		Action:    String("ACCEPT"),
 		Direction: String("INGRESSS"),
 	}
 
-	wantAcceptHeaders := []string{mediaTypeJson}
-	wantContentTypeHeaders := []string{mediaTypeJson}
-	mux.HandleFunc("/api/xfw/v1/N/rule", func(w http.ResponseWriter, r *http.Request) {
-		v := new(FirewallRuleRequest)
-		_ = json.NewDecoder(r.Body).Decode(v)
-
-		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
-		testHeader(t, r, "Content-Type", strings.Join(wantContentTypeHeaders, ", "))
-		if !reflect.DeepEqual(v, input) {
-			t.Errorf("Request body = %+v, want %+v", v, input)
+	responseBodyMock := `{
+		"ID":"00000000-0000-4000-2000-000000000002"
 		}
+		`
 
-		fmt.Fprint(w, `{"ID":"00000000-0000-4000-2000-000000000002"}`)
-	})
-
-	rule, _, err := client.Firewall.CreateRule(context.Background(), "N", input)
-	if err != nil {
-		t.Errorf("Firewall.CreateRule returned error: %v", err)
-	}
-
-	want := &FirewallRule{
+	expected := &FirewallRule{
 		ID: String("00000000-0000-4000-2000-000000000002"),
 	}
-	if !reflect.DeepEqual(rule, want) {
-		t.Errorf("Firewall.CreateRule returned %+v, want %+v", rule, want)
+
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		return client.Firewall.CreateRule(context.Background(), "N", requestBody)
 	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      requestBody,
+		ResponseBodyMock: responseBodyMock,
+		Expected:         expected,
+		Method:           method,
+		T:                t,
+	}
+
+	postTest(testParams)
 }
 
 func TestFirewallService_DeleteRule(t *testing.T) {
-	client, mux, teardown := setup()
-	defer teardown()
+	path := "/api/xfw/v1/N/rule/00000000-0000-4000-2000-000000000000"
 
-	mux.HandleFunc("/api/xfw/v1/N/rule/00000000-0000-4000-2000-000000000000", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
-	})
-
-	_, err := client.Firewall.DeleteRule(context.Background(), "N", "00000000-0000-4000-2000-000000000000")
-	if err != nil {
-		t.Errorf("FirewallRule.DeleteLabel returned error: %v", err)
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		resp, err := client.Firewall.DeleteRule(context.Background(), "N", "00000000-0000-4000-2000-000000000000")
+		return struct{}{}, resp, err
 	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      struct{}{},
+		ResponseBodyMock: "",
+		Expected:         struct{}{},
+		Method:           method,
+		T:                t,
+	}
+
+	deleteTest(testParams)
 }

--- a/enf/network_test.go
+++ b/enf/network_test.go
@@ -2,23 +2,14 @@ package enf
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"net/http"
-	"reflect"
-	"strings"
 	"testing"
 )
 
 func TestNetworkService_ListNetworks(t *testing.T) {
-	client, mux, teardown := setup()
-	defer teardown()
+	path := "/api/xcr/v2/domains/N/nws"
 
-	wantAcceptHeaders := []string{mediaTypeJson}
-	mux.HandleFunc("/api/xcr/v2/domains/N/nws", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
-		fmt.Fprint(w, `{
+	responseBodyMock := `{
 		"data": [
 			{
 				"name": "TestNetwork 1",
@@ -40,15 +31,9 @@ func TestNetworkService_ListNetworks(t *testing.T) {
 			"prev": -1
 		}
 	}
-			`)
-	})
+			`
 
-	networks, _, err := client.Network.ListNetworks(context.Background(), "N")
-	if err != nil {
-		t.Errorf("Network.ListNetworks returned error: %v", err)
-	}
-
-	want := []*Network{
+	expected := []*Network{
 		{
 			Name:        String("TestNetwork 1"),
 			Network:     String("fd00:8f80:8000:0000::/64"),
@@ -62,169 +47,158 @@ func TestNetworkService_ListNetworks(t *testing.T) {
 			Status:      String("ACTIVE"),
 		},
 	}
-	if !reflect.DeepEqual(networks, want) {
-		t.Errorf("Network.ListNetworks returned %+v, want %+v", networks, want)
+
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		return client.Network.ListNetworks(context.Background(), "N")
 	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      struct{}{},
+		ResponseBodyMock: responseBodyMock,
+		Expected:         expected,
+		Method:           method,
+		T:                t,
+	}
+
+	getTest(testParams)
 }
 
 func TestNetworkService_GetNetwork(t *testing.T) {
-	client, mux, teardown := setup()
-	defer teardown()
+	path := "/api/xcr/v2/nws/N/n"
 
-	wantAcceptHeaders := []string{mediaTypeJson}
-	mux.HandleFunc("/api/xcr/v2/nws/N/n", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
-		fmt.Fprint(w, `{
-				"data": [
-				  {
-					"name": "TestNetwork 1",
-					"network": "N/n",
-					"description": "This is a network.",
-					"status": "ACTIVE"
-				  }
-				],
-				"page": {
-				  "curr": -1,
-				  "next": -1,
-				  "prev": -1
-				}
-			  }
-			`)
-	})
-	network, _, err := client.Network.GetNetwork(context.Background(), "N/n")
-	if err != nil {
-		t.Errorf("Network.GetNetwork returned error: %v", err)
-	}
+	responseBodyMock := `{
+		"data": [
+		  {
+			"name": "TestNetwork 1",
+			"network": "N/n",
+			"description": "This is a network.",
+			"status": "ACTIVE"
+		  }
+		],
+		"page": {
+		  "curr": -1,
+		  "next": -1,
+		  "prev": -1
+		}
+	  }
+	`
 
-	want := &Network{
+	expected := &Network{
 		Name:        String("TestNetwork 1"),
 		Network:     String("N/n"),
 		Description: String("This is a network."),
 		Status:      String("ACTIVE"),
 	}
-	if !reflect.DeepEqual(network, want) {
-		t.Errorf("Network.GetNetwork returned %+v, want %+v", network, want)
+
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		return client.Network.GetNetwork(context.Background(), "N/n")
 	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      struct{}{},
+		ResponseBodyMock: responseBodyMock,
+		Expected:         expected,
+		Method:           method,
+		T:                t,
+	}
+
+	getTest(testParams)
 }
 
 func TestNetworkService_CreateNetwork(t *testing.T) {
-	client, mux, teardown := setup()
-	defer teardown()
+	path := "/api/xcr/v2/domains/1/nws"
 
-	input := &NetworkRequest{
+	requestBody := &NetworkRequest{
 		Name:        String("TestNetwork 1"),
 		Description: String("This is a new network."),
 	}
 
-	wantAcceptHeaders := []string{mediaTypeJson}
-	wantContentTypeHeaders := []string{mediaTypeJson}
-	mux.HandleFunc("/api/xcr/v2/domains/1/nws", func(w http.ResponseWriter, r *http.Request) {
-		v := new(NetworkRequest)
-		_ = json.NewDecoder(r.Body).Decode(v)
-
-		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
-		testHeader(t, r, "Content-Type", strings.Join(wantContentTypeHeaders, ", "))
-		if !reflect.DeepEqual(v, input) {
-			t.Errorf("Request body = %+v, want %+v", v, input)
-		}
-
-		fmt.Fprint(w, `{
-			"data": [
-			  {
-				"name": "TestNetwork 1",
-				"network": "N/n",
-				"description": "This is a network.",
-				"status": "ACTIVE"
-				}
-			],
-			"page": {
-			  "curr": -1,
-			  "next": -1,
-			  "prev": -1
+	responseBodyMock := `{
+		"data": [
+		  {
+			"name": "TestNetwork 1",
+			"network": "N/n",
+			"description": "This is a network.",
+			"status": "ACTIVE"
 			}
-		  }
-			`)
-	})
+		],
+		"page": {
+		  "curr": -1,
+		  "next": -1,
+		  "prev": -1
+		}
+	  }
+		`
 
-	network, _, err := client.Network.CreateNetwork(context.Background(), "1", input)
-	if err != nil {
-		t.Errorf("Network.GetNetwork returned error: %v", err)
-	}
-
-	want := &Network{
+	expected := &Network{
 		Name:        String("TestNetwork 1"),
 		Network:     String("N/n"),
 		Description: String("This is a network."),
 		Status:      String("ACTIVE"),
 	}
-	if !reflect.DeepEqual(network, want) {
-		t.Errorf("Network.GetNetwork returned %+v, want %+v", network, want)
+
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		return client.Network.CreateNetwork(context.Background(), "1", requestBody)
 	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      requestBody,
+		ResponseBodyMock: responseBodyMock,
+		Expected:         expected,
+		Method:           method,
+		T:                t,
+	}
+
+	postTest(testParams)
 }
 
 func TestNetworkService_UpdateNetwork(t *testing.T) {
-	client, mux, teardown := setup()
-	defer teardown()
+	path := "/api/xcr/v2/nws/N/n"
 
-	wantAcceptHeaders := []string{mediaTypeJson}
-	wantContentTypeHeaders := []string{mediaTypeJson}
-
-	// expected body for PUT endpoint
-	input := &NetworkRequest{
+	requestBody := &NetworkRequest{
 		Name:        String("TestNetwork 334"),
 		Description: String("Trying to update the network.."),
 	}
 
-	mux.HandleFunc("/api/xcr/v2/nws/N/n", func(w http.ResponseWriter, r *http.Request) {
-		v := new(NetworkRequest)
-		_ = json.NewDecoder(r.Body).Decode(v)
-
-		testMethod(t, r, "PUT")
-		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ","))
-		testHeader(t, r, "Content-Type", strings.Join(wantContentTypeHeaders, ", "))
-		if !reflect.DeepEqual(v, input) {
-			t.Errorf("Request body = %+v, want %+v", v, input)
-		}
-
-		fmt.Fprintf(w, `{
-			"data": [
-				{
-					"name": "TestNetwork 334",
-					"network": "N/n",
-					"description":  "Trying to update the network..",
-					"status": "ACTIVE"
-				}
-			],
-			"page": {
-				"curr": -1,
-				"next": -1,
-				"prev": -1
+	responseBodyMock := `{
+		"data": [
+			{
+				"name": "TestNetwork 334",
+				"network": "N/n",
+				"description":  "Trying to update the network..",
+				"status": "ACTIVE"
 			}
+		],
+		"page": {
+			"curr": -1,
+			"next": -1,
+			"prev": -1
 		}
-	`)
-	})
+	}
+		`
 
-	fields := &NetworkRequest{
-		Name:        String("TestNetwork 334"),
-		Description: String("Trying to update the network.."),
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		return client.Network.UpdateNetwork(context.Background(), "N/n", requestBody)
 	}
 
-	// now, update the network we just created
-	updatedNetwork, _, err := client.Network.UpdateNetwork(context.Background(), "N/n", fields)
-	if err != nil {
-		t.Errorf("Network.UpdateNetwork returned error: %v", err)
-	}
-
-	want := &Network{
+	expected := &Network{
 		Name:        String("TestNetwork 334"),
 		Network:     String("N/n"),
 		Description: String("Trying to update the network.."),
 		Status:      String("ACTIVE"),
 	}
-	if !reflect.DeepEqual(updatedNetwork, want) {
-		t.Errorf("Network.UpdateNetwork returned %+v, want %+v", updatedNetwork, want)
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      requestBody,
+		ResponseBodyMock: responseBodyMock,
+		Expected:         expected,
+		Method:           method,
+		T:                t,
 	}
 
+	putTest(testParams)
 }


### PR DESCRIPTION
In order to eliminate the significant code reuse between testing suites - namely, boilerplate to set up the mock server and check headers for `GET`, `POST`, `PUT`, and `DELETE` requests, etc. - I decided to add some simple helper functions to make setting up these tests a lot easier.

All the new methods are located in `enf_test.go`. In addition, I refactored _almost_ all the existing test suites to use these methods; a few tests had a bit too much complexity to be refactored into a single helper method call. 

@drbild Let me know your thoughts! This is a pretty substantial PR, so I may have made some typos or lack comments in certain areas.