### PR TITLE
Fixing body of put requests for ActivateDomain and DeactivateDomain

### DIFF
--- a/enf/domain.go
+++ b/enf/domain.go
@@ -62,7 +62,7 @@ func (s *DomainService) CreateDomain(ctx context.Context, req *DomainRequest) (*
 // ActivateDomain activates the given domain (sets the status field to ACTIVE)
 func (s *DomainService) ActivateDomain(ctx context.Context, domain string) (*Domain, *http.Response, error) {
 	path := fmt.Sprintf("api/xcr/v2/domains/%v/status", domain)
-	body, resp, err := s.client.put(ctx, path, new(domainResponse), struct{}{})
+	body, resp, err := s.client.put(ctx, path, new(domainResponse), "ACTIVE")
 	if err != nil {
 		return nil, resp, err
 	}
@@ -71,7 +71,11 @@ func (s *DomainService) ActivateDomain(ctx context.Context, domain string) (*Dom
 }
 
 // DeactivateDomain deactivates the given domain (sets the status field to READY)
-func (s *DomainService) DeactivateDomain(ctx context.Context, domain string) (*http.Response, error) {
+func (s *DomainService) DeactivateDomain(ctx context.Context, domain string) (*Domain, *http.Response, error) {
 	path := fmt.Sprintf("api/xcr/v2/domains/%v/status", domain)
-	return s.client.delete(ctx, path)
+	body, resp, err := s.client.put(ctx, path, new(domainResponse), "READY")
+	if err != nil {
+		return nil, resp, err
+	}
+	return body.(*domainResponse).Data[0], resp, nil
 }

--- a/enf/domain_test.go
+++ b/enf/domain_test.go
@@ -154,9 +154,11 @@ func TestDomainService_ActivateDomain(t *testing.T) {
 	defer teardown()
 
 	wantAcceptHeaders := []string{mediaTypeJson}
+	wantContentTypeHeaders := []string{mediaTypeJson}
 	mux.HandleFunc("/api/xcr/v2/domains/N/n0/status", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
+		testHeader(t, r, "Content-Type", strings.Join(wantContentTypeHeaders, ", "))
 		fmt.Fprint(w, `{
 			"data": [
 				{
@@ -194,9 +196,11 @@ func TestDomainService_DeactivateDomain(t *testing.T) {
 	defer teardown()
 
 	wantAcceptHeaders := []string{mediaTypeJson}
+	wantContentTypeHeaders := []string{mediaTypeJson}
 	mux.HandleFunc("/api/xcr/v2/domains/N/n0/status", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
+		testMethod(t, r, "PUT")
 		testHeader(t, r, "Accept", strings.Join(wantAcceptHeaders, ", "))
+		testHeader(t, r, "Content-Type", strings.Join(wantContentTypeHeaders, ", "))
 		fmt.Fprint(w, `{
 			"data": [
 				{
@@ -214,8 +218,17 @@ func TestDomainService_DeactivateDomain(t *testing.T) {
 				`)
 	})
 
-	_, err := client.Domains.DeactivateDomain(context.Background(), "N/n0")
+	deactivatedDomain, _, err := client.Domains.DeactivateDomain(context.Background(), "N/n0")
 	if err != nil {
 		t.Errorf("Domains.DeactivateDomain returned error: %v", err)
+	}
+
+	want := &Domain{
+		Name:    String("test.domain.1"),
+		Network: String("N/n0"),
+		Status:  String("READY"),
+	}
+	if !reflect.DeepEqual(deactivatedDomain, want) {
+		t.Errorf("Domains.DeactivateDomain returned %+v, want %+v", deactivatedDomain, want)
 	}
 }


### PR DESCRIPTION
Fixes #23 

As the issue says, `go-enf` now has a bug since Venkat changed the request type for `ActivateDomain` and `DeactivateDomain`. This PR addresses this issue.