### PR TITLE
Adding support for user methods

### DIFF
--- a/enf/dns_zone.go
+++ b/enf/dns_zone.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -42,7 +43,7 @@ type zoneResponse struct {
 // ListZones lists all the DNS zones for a given ENF domain (::/48 address).
 func (s *DNSService) ListZones(ctx context.Context) ([]*Zone, *http.Response, error) {
 	path := "api/xdns/2019-05-27/zones"
-	body, resp, err := s.client.get(ctx, path, new(zoneResponse))
+	body, resp, err := s.client.get(ctx, path, url.Values{}, new(zoneResponse))
 	if err != nil {
 		return nil, resp, err
 	}
@@ -53,7 +54,7 @@ func (s *DNSService) ListZones(ctx context.Context) ([]*Zone, *http.Response, er
 // GetZone gets a DNS zone given its UUID.
 func (s *DNSService) GetZone(ctx context.Context, zoneUUID string) (*Zone, *http.Response, error) {
 	path := fmt.Sprintf("api/xdns/2019-05-27/zones/%v", zoneUUID)
-	body, resp, err := s.client.get(ctx, path, new(zoneResponse))
+	body, resp, err := s.client.get(ctx, path, url.Values{}, new(zoneResponse))
 	if err != nil {
 		return nil, resp, err
 	}

--- a/enf/domain.go
+++ b/enf/domain.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 )
 
 // Domain represents a domain in the ENF.
@@ -29,7 +30,7 @@ type domainResponse struct {
 // ListDomains lists all available domains on the ENF.
 func (s *DomainService) ListDomains(ctx context.Context) ([]*Domain, *http.Response, error) {
 	path := fmt.Sprintf("api/xcr/v2/domains")
-	body, resp, err := s.client.get(ctx, path, new(domainResponse))
+	body, resp, err := s.client.get(ctx, path, url.Values{}, new(domainResponse))
 	if err != nil {
 		return nil, resp, err
 	}
@@ -40,7 +41,7 @@ func (s *DomainService) ListDomains(ctx context.Context) ([]*Domain, *http.Respo
 // GetDomain gets the information of a specified domain.
 func (s *DomainService) GetDomain(ctx context.Context, domain string) (*Domain, *http.Response, error) {
 	path := fmt.Sprintf("api/xcr/v2/domains/%v", domain)
-	body, resp, err := s.client.get(ctx, path, new(domainResponse))
+	body, resp, err := s.client.get(ctx, path, url.Values{}, new(domainResponse))
 	if err != nil {
 		return nil, resp, err
 	}

--- a/enf/domain_ratelimit.go
+++ b/enf/domain_ratelimit.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 )
 
 // DomainService handles communication with the domain-related methods
@@ -28,7 +29,7 @@ type domainRateLimitResponse struct {
 // GetDefaultEndpointRateLimits gets the default rate limits for an endpoint in the given domain.
 func (s *DomainService) GetDefaultEndpointRateLimits(ctx context.Context, domain string) (*DomainRateLimits, *http.Response, error) {
 	path := fmt.Sprintf("api/xcr/v2/domains/%v/ep_rate_limits/default", domain)
-	body, resp, err := s.client.get(ctx, path, new(domainRateLimitResponse))
+	body, resp, err := s.client.get(ctx, path, url.Values{}, new(domainRateLimitResponse))
 	if err != nil {
 		return nil, resp, err
 	}
@@ -38,7 +39,7 @@ func (s *DomainService) GetDefaultEndpointRateLimits(ctx context.Context, domain
 // GetMaxDefaultEndpointRateLimits gets the max rate limits for an endpoint in the given domain.
 func (s *DomainService) GetMaxDefaultEndpointRateLimits(ctx context.Context, domain string) (*DomainRateLimits, *http.Response, error) {
 	path := fmt.Sprintf("api/xcr/v2/domains/%v/ep_rate_limits/max", domain)
-	body, resp, err := s.client.get(ctx, path, new(domainRateLimitResponse))
+	body, resp, err := s.client.get(ctx, path, url.Values{}, new(domainRateLimitResponse))
 	if err != nil {
 		return nil, resp, err
 	}

--- a/enf/endpoint_ratelimit.go
+++ b/enf/endpoint_ratelimit.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 )
 
 // EndpointService handles communication with all endpoint related methods within
@@ -29,7 +30,7 @@ type endpointRateLimitResponse struct {
 // GetCurrentRateLimits gets the current rate limits for the given endpoint IPv6 address.
 func (s *EndpointService) GetCurrentRateLimits(ctx context.Context, endpointIPv6 string) (*EndpointRateLimits, *http.Response, error) {
 	path := fmt.Sprintf("api/xcr/v2/cxns/%v/ep_rate_limits/current", endpointIPv6)
-	body, resp, err := s.client.get(ctx, path, new(endpointRateLimitResponse))
+	body, resp, err := s.client.get(ctx, path, url.Values{}, new(endpointRateLimitResponse))
 	if err != nil {
 		return nil, resp, err
 	}
@@ -39,7 +40,7 @@ func (s *EndpointService) GetCurrentRateLimits(ctx context.Context, endpointIPv6
 // GetMaxRateLimits gets the max rate limits for the given endpoint IPv6 address.
 func (s *EndpointService) GetMaxRateLimits(ctx context.Context, endpointIPv6 string) (*EndpointRateLimits, *http.Response, error) {
 	path := fmt.Sprintf("api/xcr/v2/cxns/%v/ep_rate_limits/max", endpointIPv6)
-	body, resp, err := s.client.get(ctx, path, new(endpointRateLimitResponse))
+	body, resp, err := s.client.get(ctx, path, url.Values{}, new(endpointRateLimitResponse))
 	if err != nil {
 		return nil, resp, err
 	}

--- a/enf/enf.go
+++ b/enf/enf.go
@@ -53,11 +53,12 @@ type Client struct {
 
 	// Services used for talking to different parts of the ENF API.
 	Auth     *AuthService
-	Firewall *FirewallService
-	Network  *NetworkService
 	DNS      *DNSService
 	Domains  *DomainService
 	Endpoint *EndpointService
+	Firewall *FirewallService
+	Network  *NetworkService
+	User     *UserService
 }
 
 type service struct {
@@ -69,11 +70,14 @@ type service struct {
 // For usage examples, see the methods in network.go or firewall.go
 
 // get makes a get request to the given path and stores the response in the given body object.
-func (c *Client) get(ctx context.Context, path string, body interface{}) (interface{}, *http.Response, error) {
+func (c *Client) get(ctx context.Context, path string, queryParameters url.Values, body interface{}) (interface{}, *http.Response, error) {
 	req, err := c.NewRequest("GET", path, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// Add the query parameters to the request URL.
+	req.URL.RawQuery = queryParameters.Encode()
 
 	return c.makeRequest(ctx, req, body)
 }
@@ -132,11 +136,12 @@ func NewClient(domain string, httpClient *http.Client) (*Client, error) {
 	c := &Client{client: httpClient, Domain: domain, BaseURL: baseURL, UserAgent: defaultUserAgent}
 	c.common.client = c
 	c.Auth = (*AuthService)(&c.common)
-	c.Firewall = (*FirewallService)(&c.common)
-	c.Network = (*NetworkService)(&c.common)
 	c.Domains = (*DomainService)(&c.common)
 	c.Endpoint = (*EndpointService)(&c.common)
 	c.DNS = (*DNSService)(&c.common)
+	c.Firewall = (*FirewallService)(&c.common)
+	c.Network = (*NetworkService)(&c.common)
+	c.User = (*UserService)(&c.common)
 	return c, nil
 }
 

--- a/enf/firewall.go
+++ b/enf/firewall.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 )
 
 var (
@@ -48,7 +49,7 @@ type FirewallRuleRequest struct {
 // ListRules gets all the firewall rules for the given network.
 func (s *FirewallService) ListRules(ctx context.Context, network string) ([]*FirewallRule, *http.Response, error) {
 	path := fmt.Sprintf("api/xfw/v1/%v/rule", network)
-	body, resp, err := s.client.get(ctx, path, new([]*FirewallRule))
+	body, resp, err := s.client.get(ctx, path, url.Values{}, new([]*FirewallRule))
 	if err != nil {
 		return nil, resp, err
 	}

--- a/enf/network.go
+++ b/enf/network.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 )
 
 // NetworkService handles communication with the network related
@@ -35,7 +36,7 @@ type networkResponse struct {
 // ListNetworks gets a list of all the networks under a given domain.
 func (s *NetworkService) ListNetworks(ctx context.Context, domain string) ([]*Network, *http.Response, error) {
 	path := fmt.Sprintf("api/xcr/v2/domains/%v/nws", domain)
-	body, resp, err := s.client.get(ctx, path, new(networkResponse))
+	body, resp, err := s.client.get(ctx, path, url.Values{}, new(networkResponse))
 	if err != nil {
 		return nil, resp, err
 	}
@@ -45,7 +46,7 @@ func (s *NetworkService) ListNetworks(ctx context.Context, domain string) ([]*Ne
 // GetNetwork gets the network object for a given network address of the form <prefix>/<prefix_length>.
 func (s *NetworkService) GetNetwork(ctx context.Context, network string) (*Network, *http.Response, error) {
 	path := fmt.Sprintf("api/xcr/v2/nws/%s", network)
-	body, resp, err := s.client.get(ctx, path, new(networkResponse))
+	body, resp, err := s.client.get(ctx, path, url.Values{}, new(networkResponse))
 	if err != nil {
 		return nil, resp, err
 	}

--- a/enf/network_ratelimit.go
+++ b/enf/network_ratelimit.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 )
 
 // NetworkRateLimits represents the values of rate limits for a network.
@@ -25,7 +26,7 @@ type networkRateLimitResponse struct {
 // GetDefaultEndpointRateLimits gets the default rate limits for endpoints in the given network.
 func (s *NetworkService) GetDefaultEndpointRateLimits(ctx context.Context, network string) (*NetworkRateLimits, *http.Response, error) {
 	path := fmt.Sprintf("api/xcr/v2/nws/%v/ep_rate_limits/default", network)
-	body, resp, err := s.client.get(ctx, path, new(networkRateLimitResponse))
+	body, resp, err := s.client.get(ctx, path, url.Values{}, new(networkRateLimitResponse))
 	if err != nil {
 		return nil, resp, err
 	}
@@ -35,7 +36,7 @@ func (s *NetworkService) GetDefaultEndpointRateLimits(ctx context.Context, netwo
 // GetMaxDefaultEndpointRateLimits gets the max default rate limits for endpoints in the given network.
 func (s *NetworkService) GetMaxDefaultEndpointRateLimits(ctx context.Context, network string) (*NetworkRateLimits, *http.Response, error) {
 	path := fmt.Sprintf("api/xcr/v2/nws/%v/ep_rate_limits/max", network)
-	body, resp, err := s.client.get(ctx, path, new(networkRateLimitResponse))
+	body, resp, err := s.client.get(ctx, path, url.Values{}, new(networkRateLimitResponse))
 	if err != nil {
 		return nil, resp, err
 	}

--- a/enf/user.go
+++ b/enf/user.go
@@ -1,0 +1,195 @@
+package enf
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// UserService handles communication with the user related methods of the
+// ENF API. These methods include sending, resending, accepting, deleting, and
+// listing new user invites, viewing the users for a domain, and resetting user passwords.
+type UserService service
+
+// Invite represents an invite to a new user.
+type Invite struct {
+	ID           *int       `json:"id"`
+	CreatedBy    *string    `json:"created_by"`
+	InsertedDate *time.Time `json:"inserted_date"`
+	ModifiedDate *time.Time `json:"modified_data"`
+	Version      *int       `json:"version"`
+	DomainID     *int       `json:"domain_id"`
+	Email        *string    `json:"email"`
+	InviteToken  *string    `json:"invite_token"`
+	InvitedBy    *string    `json:"invited_by"`
+	Name         *string    `json:"name"`
+	Type         *string    `json:"type"`
+}
+
+// User represents an ENF user.
+type User struct {
+	UserID      *int       `json:"user_id"`
+	Username    *string    `json:"username"`
+	Description *string    `json:"description"`
+	FullName    *string    `json:"full_name"`
+	LastLogin   *time.Time `json:"last_login"`
+	DomainID    *int       `json:"domain_id"`
+	Type        *string    `json:"type"`
+	ResetCode   *string    `json:"reset_code"`
+	ResetTime   *time.Time `json:"reset_time"`
+	Status      *string    `json:"status"`
+}
+
+// SendInviteRequest represents the body of the request to send an invite.
+type SendInviteRequest struct {
+	Email    *string `json:"email"`
+	FullName *string `json:"full_name"`
+	UserType *string `json:"user_type"`
+}
+
+// AcceptInviteRequest represents the body of the request to accept an invite.
+type AcceptInviteRequest struct {
+	Email    *string `json:"email"`
+	Code     *string `json:"code"`
+	Name     *string `json:"name"`
+	Password *string `json:"password"`
+}
+
+// UpdateUserStatusRequest represents the body of the request to update a user's status.
+type UpdateUserStatusRequest struct {
+	Status *string `json:"status"`
+}
+
+// ResetPasswordRequest represents the body of the request to reset a user's password.
+type ResetPasswordRequest struct {
+	Email    *string `json:"email"`
+	Code     *string `json:"code"`
+	Password *string `json:"pwd"`
+}
+
+type inviteResponse struct {
+	Data []*Invite              `json:"data"`
+	Page map[string]interface{} `json:"page"`
+}
+
+type userResponse struct {
+	Data []*User                `json:"data"`
+	Page map[string]interface{} `json:"page"`
+}
+
+type emptyResponse []interface{}
+
+// ListUsersForDomainAddress gets the list of users for a given domain address.
+func (s *UserService) ListUsersForDomainAddress(ctx context.Context, address string) ([]*User, *http.Response, error) {
+	path := fmt.Sprintf("api/xcr/v2/domains/%v/users", address)
+	body, resp, err := s.client.get(ctx, path, url.Values{}, new(userResponse))
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return body.(*userResponse).Data, resp, nil
+}
+
+// ListUsersForDomainID gets a list of users for a given unique domain identifier.
+func (s *UserService) ListUsersForDomainID(ctx context.Context, id string) ([]*User, *http.Response, error) {
+	path := fmt.Sprintf("api/xcr/v2/domains/%v/users", id)
+	body, resp, err := s.client.get(ctx, path, url.Values{}, new(userResponse))
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return body.(*userResponse).Data, resp, nil
+}
+
+// UpdateUserStatus updates the status of a user to "ACTIVE" or "INACTIVE".
+func (s *UserService) UpdateUserStatus(ctx context.Context, userID int, updateUserStatusRequest *UpdateUserStatusRequest) (*http.Response, error) {
+	path := fmt.Sprintf("api/xcr/v2/users/%v/status", userID)
+	_, resp, err := s.client.put(ctx, path, new(emptyResponse), updateUserStatusRequest)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// ListInvitesForDomainAddress gets a list of active invites for a given domain address.
+func (s *UserService) ListInvitesForDomainAddress(ctx context.Context, address string) ([]*Invite, *http.Response, error) {
+	path := fmt.Sprintf("api/xcr/v2/domains/%v/invites", address)
+	body, resp, err := s.client.get(ctx, path, url.Values{}, new(inviteResponse))
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return body.(*inviteResponse).Data, resp, nil
+}
+
+// SendNewInvite sends a new invite for a user to join the domain with the given address.
+func (s *UserService) SendNewInvite(ctx context.Context, address string, inviteRequest *SendInviteRequest) (*Invite, *http.Response, error) {
+	path := fmt.Sprintf("api/xcr/v2/domains/%v/invites", address)
+	body, resp, err := s.client.post(ctx, path, new(inviteResponse), inviteRequest)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return body.(*inviteResponse).Data[0], resp, nil
+}
+
+// AcceptInvite accepts an invite.
+func (s *UserService) AcceptInvite(ctx context.Context, acceptInviteRequest *AcceptInviteRequest) (*http.Response, error) {
+	path := "api/xcr/v2/users/invites"
+	_, resp, err := s.client.post(ctx, path, new(emptyResponse), acceptInviteRequest)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// ResendInvite resends an invite to the given email address.
+func (s *UserService) ResendInvite(ctx context.Context, email string) (*http.Response, error) {
+	path := fmt.Sprintf("api/xcr/v2/invites/%v", email)
+	_, resp, err := s.client.put(ctx, path, new(emptyResponse), struct{}{})
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// DeleteInvite deletes an invite to the given email address.
+func (s *UserService) DeleteInvite(ctx context.Context, email string) (*http.Response, error) {
+	path := fmt.Sprintf("api/xcr/v2/invites/%v", email)
+	resp, err := s.client.delete(ctx, path)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// EmailResetPasswordCode emails a reset password code to the given email address.
+func (s *UserService) EmailResetPasswordCode(ctx context.Context, email string) (*http.Response, error) {
+	path := "api/xcr/v2/users/reset"
+
+	queryParameters := url.Values{}
+	queryParameters.Add("email", email)
+	_, resp, err := s.client.get(ctx, path, queryParameters, new(emptyResponse))
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// ResetPassword resets a user's password.
+func (s *UserService) ResetPassword(ctx context.Context, resetPasswordRequest *ResetPasswordRequest) (*http.Response, error) {
+	path := "api/xcr/v2/users/reset"
+	_, resp, err := s.client.post(ctx, path, new(emptyResponse), resetPasswordRequest)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}

--- a/enf/user_test.go
+++ b/enf/user_test.go
@@ -1,0 +1,315 @@
+package enf
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestUserService_ListUsersForDomainAddress(t *testing.T) {
+	path := "/api/xcr/v2/domains/N/users"
+
+	responseBodyMock := `{
+		"data": [
+			{
+				"user_id": 1,
+				"username": "user@acme",
+				"full_name": "Xaptum User",
+				"status": "ACTIVE"
+			}
+		]
+	}`
+
+	expected := []*User{
+		{
+			UserID:   Int(1),
+			Username: String("user@acme"),
+			FullName: String("Xaptum User"),
+			Status:   String("ACTIVE"),
+		},
+	}
+
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		return client.User.ListUsersForDomainAddress(context.Background(), "N")
+	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      struct{}{},
+		ResponseBodyMock: responseBodyMock,
+		Expected:         expected,
+		Method:           method,
+		T:                t,
+	}
+
+	getTest(testParams)
+}
+
+func TestUserService_ListUsersForDomainID(t *testing.T) {
+	path := "/api/xcr/v2/domains/1/users"
+
+	responseBodyMock := `{
+		"data": [
+			{
+				"user_id": 1,
+				"username": "user@acme",
+				"full_name": "Xaptum User",
+				"status": "ACTIVE"
+			}
+		]
+	}`
+
+	expected := []*User{
+		{
+			UserID:   Int(1),
+			Username: String("user@acme"),
+			FullName: String("Xaptum User"),
+			Status:   String("ACTIVE"),
+		},
+	}
+
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		return client.User.ListUsersForDomainID(context.Background(), "1")
+	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      struct{}{},
+		ResponseBodyMock: responseBodyMock,
+		Expected:         expected,
+		Method:           method,
+		T:                t,
+	}
+
+	getTest(testParams)
+}
+
+func TestUserService_UpdateUserStatus(t *testing.T) {
+	path := "/api/xcr/v2/users/61/status"
+
+	requestBody := &UpdateUserStatusRequest{
+		Status: String("INACTIVE"),
+	}
+
+	responseBodyMock := `[]`
+
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		resp, err := client.User.UpdateUserStatus(context.Background(), 61, requestBody)
+		return struct{}{}, resp, err
+	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      requestBody,
+		ResponseBodyMock: responseBodyMock,
+		Expected:         struct{}{},
+		Method:           method,
+		T:                t,
+	}
+
+	putTest(testParams)
+}
+
+func TestUserService_ListInvitesForDomainAddress(t *testing.T) {
+	path := "/api/xcr/v2/domains/1/invites"
+
+	responseBodyMock := `{
+		"data": [
+			{
+				"id": 1,
+				"email": "user@acme.com",
+				"name": "Xaptum User",
+				"invite_token": "token1234"
+			}
+		]
+	}`
+
+	expected := []*Invite{
+		{
+			ID:          Int(1),
+			Email:       String("user@acme.com"),
+			Name:        String("Xaptum User"),
+			InviteToken: String("token1234"),
+		},
+	}
+
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		return client.User.ListInvitesForDomainAddress(context.Background(), "1")
+	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      struct{}{},
+		ResponseBodyMock: responseBodyMock,
+		Expected:         expected,
+		Method:           method,
+		T:                t,
+	}
+
+	getTest(testParams)
+}
+
+func TestUserService_SendNewInvite(t *testing.T) {
+	path := "/api/xcr/v2/domains/1/invites"
+
+	requestBody := &SendInviteRequest{
+		Email:    String("user@acme.com"),
+		FullName: String("Xaptum User"),
+		UserType: String("DOMAIN_USER"),
+	}
+
+	responseBodyMock := `{
+		"data": [
+			{
+				"id": 1,
+				"email": "user@acme.com",
+				"name": "Xaptum User",
+				"type": "DOMAIN_USER"
+			}
+		]
+	}`
+
+	expected := &Invite{
+		ID:    Int(1),
+		Email: String("user@acme.com"),
+		Name:  String("Xaptum User"),
+		Type:  String("DOMAIN_USER"),
+	}
+
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		return client.User.SendNewInvite(context.Background(), "1", requestBody)
+	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      requestBody,
+		ResponseBodyMock: responseBodyMock,
+		Expected:         expected,
+		Method:           method,
+		T:                t,
+	}
+
+	postTest(testParams)
+}
+
+func TestUserService_AcceptInvite(t *testing.T) {
+	path := "/api/xcr/v2/users/invites"
+
+	requestBody := &AcceptInviteRequest{
+		Email:    String("user@acme.com"),
+		Code:     String("token1234"),
+		Name:     String("Xaptum User"),
+		Password: String("User1234!"),
+	}
+	responseBodyMock := `[]`
+
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		resp, err := client.User.AcceptInvite(context.Background(), requestBody)
+		return struct{}{}, resp, err
+	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      requestBody,
+		ResponseBodyMock: responseBodyMock,
+		Expected:         struct{}{},
+		Method:           method,
+		T:                t,
+	}
+
+	postTest(testParams)
+}
+
+func TestUserService_ResendInvite(t *testing.T) {
+	path := "/api/xcr/v2/invites/user@acme.com"
+
+	responseBodyMock := `[]`
+
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		resp, err := client.User.ResendInvite(context.Background(), "user@acme.com")
+		return struct{}{}, resp, err
+	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      struct{}{},
+		ResponseBodyMock: responseBodyMock,
+		Expected:         struct{}{},
+		Method:           method,
+		T:                t,
+	}
+
+	putTest(testParams)
+}
+
+func TestUserService_DeleteInvite(t *testing.T) {
+	path := "/api/xcr/v2/invites/user@acme.com"
+
+	responseBodyMock := `[]`
+
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		resp, err := client.User.DeleteInvite(context.Background(), "user@acme.com")
+		return struct{}{}, resp, err
+	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      struct{}{},
+		ResponseBodyMock: responseBodyMock,
+		Expected:         struct{}{},
+		Method:           method,
+		T:                t,
+	}
+
+	deleteTest(testParams)
+}
+
+func TestUserService_EmailResetPasswordCode(t *testing.T) {
+	path := "/api/xcr/v2/users/reset"
+
+	responseBodyMock := `[]`
+
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		resp, err := client.User.EmailResetPasswordCode(context.Background(), "user@acme.com")
+		return struct{}{}, resp, err
+	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      struct{}{},
+		ResponseBodyMock: responseBodyMock,
+		Expected:         struct{}{},
+		Method:           method,
+		T:                t,
+	}
+
+	getTest(testParams)
+}
+
+func TestUserService_ResetPassword(t *testing.T) {
+	path := "/api/xcr/v2/users/reset"
+
+	requestBody := &ResetPasswordRequest{
+		Email:    String("user@acme.com"),
+		Code:     String("token1234"),
+		Password: String("User1234!"),
+	}
+
+	responseBodyMock := `[]`
+
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		resp, err := client.User.ResetPassword(context.Background(), requestBody)
+		return struct{}{}, resp, err
+	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      requestBody,
+		ResponseBodyMock: responseBodyMock,
+		Expected:         struct{}{},
+		Method:           method,
+		T:                t,
+	}
+
+	postTest(testParams)
+}


### PR DESCRIPTION
Fixes #29 

I also refactored the `get` helper method to take in any relevant query parameters (this mattered for `GET /api/xcr/v2/users/reset` to email a reset password code), which is why you see so many files included in the diff.