### PR TITLE
Update user resources for API v3

### DIFF
--- a/enf/auth.go
+++ b/enf/auth.go
@@ -26,12 +26,12 @@ type AuthRequest struct {
 // Credentials represents the authentication credentials returned by
 // the auth API.
 type Credentials struct {
-	Username      *string `json:"username"`
-	Token         *string `json:"token"`
-	UserID        *int64  `json:"user_id"`
-	UserType      *string `json:"type"`
-	DomainID      *int64  `json:"domain_id"`
-	DomainNetwork *string `json:"domain_network"`
+	Username *string     `json:"username"`
+	Token    *string     `json:"token"`
+	UserID   *int64      `json:"user_id"`
+	Roles    []*UserRole `json:"roles"`
+	DomainID *int64      `json:"domain_id"`
+	Domain   *string     `json:"domain"`
 }
 
 type authResponse struct {
@@ -49,7 +49,7 @@ func (s *AuthService) Authenticate(ctx context.Context, authReq *AuthRequest) (*
 		return nil, nil, ErrMissingPassword
 	}
 
-	endpoint := "/api/xcr/v2/xauth"
+	endpoint := "/api/xcr/v3/xauth"
 
 	body, resp, err := s.client.post(ctx, endpoint, new(authResponse), authReq)
 	if err != nil {

--- a/enf/auth_test.go
+++ b/enf/auth_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestAuthService_Authenticate(t *testing.T) {
-	path := "/api/xcr/v2/xauth"
+	path := "/api/xcr/v3/xauth"
 
 	requestBody := &AuthRequest{
 		Username: String("user"),
@@ -19,18 +19,29 @@ func TestAuthService_Authenticate(t *testing.T) {
 			{
 				"username":"user",
 				"token":"12345678",
-				"user_id":1
+				"user_id":1,
+				"roles": [
+					{
+						"cidr" : "N/n0",
+						"role" : "NETWORK_USER"
+					}
+				]
 			}
 		],
 		"page": {
-
-			}
+		}
 		}`
 
 	expected := &Credentials{
 		Username: String("user"),
 		Token:    String("12345678"),
 		UserID:   Int64(1),
+		Roles: []*UserRole{
+			{
+				CIDR: String("N/n0"),
+				Role: String("NETWORK_USER"),
+			},
+		},
 	}
 
 	method := func(client *Client) (interface{}, *http.Response, error) {

--- a/enf/dns_zone.go
+++ b/enf/dns_zone.go
@@ -87,7 +87,7 @@ func (s *DNSService) UpdateZone(ctx context.Context, zoneUUID string, req *Updat
 // DeleteZone deletes a zone given its UUID.
 func (s *DNSService) DeleteZone(ctx context.Context, zoneUUID string) (*http.Response, error) {
 	path := fmt.Sprintf("api/xdns/2019-05-27/zones/%v", zoneUUID)
-	resp, err := s.client.delete(ctx, path)
+	resp, err := s.client.delete(ctx, path, url.Values{})
 	if err != nil {
 		return resp, err
 	}

--- a/enf/enf.go
+++ b/enf/enf.go
@@ -101,11 +101,15 @@ func (c *Client) put(ctx context.Context, path string, body interface{}, fields 
 }
 
 // delete makes delete requests to the given path.
-func (c *Client) delete(ctx context.Context, path string) (*http.Response, error) {
+func (c *Client) delete(ctx context.Context, path string, queryParameters url.Values) (*http.Response, error) {
 	req, err := c.NewRequest("DELETE", path, nil)
 	if err != nil {
 		return nil, err
 	}
+
+	// Add the query parameters to the request URL.
+	req.URL.RawQuery = queryParameters.Encode()
+
 	return c.Do(ctx, req, nil)
 }
 

--- a/enf/firewall.go
+++ b/enf/firewall.go
@@ -86,5 +86,5 @@ func (s *FirewallService) CreateRule(ctx context.Context, network string, rule *
 // DeleteRule deletes the firewall rule associated with the given network address and ID.
 func (s *FirewallService) DeleteRule(ctx context.Context, network string, id string) (*http.Response, error) {
 	path := fmt.Sprintf("api/xfw/v1/%v/rule/%v", network, id)
-	return s.client.delete(ctx, path)
+	return s.client.delete(ctx, path, url.Values{})
 }

--- a/enf/user_invite.go
+++ b/enf/user_invite.go
@@ -16,18 +16,20 @@ type Invite struct {
 	ModifiedDate *time.Time `json:"modified_data"`
 	Version      *int       `json:"version"`
 	DomainID     *int       `json:"domain_id"`
+	Domain       *string    `json:"domain"`
+	Role         *UserRole  `json:"role"`
 	Email        *string    `json:"email"`
 	InviteToken  *string    `json:"invite_token"`
 	InvitedBy    *string    `json:"invited_by"`
 	Name         *string    `json:"name"`
-	Type         *string    `json:"type"`
 }
 
 // SendInviteRequest represents the body of the request to send an invite.
 type SendInviteRequest struct {
-	Email    *string `json:"email"`
-	FullName *string `json:"full_name"`
-	UserType *string `json:"user_type"`
+	Email    *string     `json:"email"`
+	FullName *string     `json:"full_name"`
+	Domain   *string     `json:"domain"`
+	Roles    []*UserRole `json:"roles"`
 }
 
 // AcceptInviteRequest represents the body of the request to accept an invite.
@@ -43,9 +45,9 @@ type inviteResponse struct {
 	Page map[string]interface{} `json:"page"`
 }
 
-// ListInvitesForDomainAddress gets a list of active invites for a given domain address.
-func (s *UserService) ListInvitesForDomainAddress(ctx context.Context, address string) ([]*Invite, *http.Response, error) {
-	path := fmt.Sprintf("api/xcr/v2/domains/%v/invites", address)
+// ListInvites gets a list of active invites.
+func (s *UserService) ListInvites(ctx context.Context) ([]*Invite, *http.Response, error) {
+	path := fmt.Sprintf("api/xcr/v3/invites")
 	body, resp, err := s.client.get(ctx, path, url.Values{}, new(inviteResponse))
 	if err != nil {
 		return nil, resp, err
@@ -54,9 +56,9 @@ func (s *UserService) ListInvitesForDomainAddress(ctx context.Context, address s
 	return body.(*inviteResponse).Data, resp, nil
 }
 
-// SendNewInvite sends a new invite for a user to join the domain with the given address.
-func (s *UserService) SendNewInvite(ctx context.Context, address string, inviteRequest *SendInviteRequest) (*Invite, *http.Response, error) {
-	path := fmt.Sprintf("api/xcr/v2/domains/%v/invites", address)
+// SendInvite sends an invite for a new user.
+func (s *UserService) SendInvite(ctx context.Context, inviteRequest *SendInviteRequest) (*Invite, *http.Response, error) {
+	path := fmt.Sprintf("api/xcr/v3/invites")
 	body, resp, err := s.client.post(ctx, path, new(inviteResponse), inviteRequest)
 	if err != nil {
 		return nil, resp, err
@@ -67,7 +69,7 @@ func (s *UserService) SendNewInvite(ctx context.Context, address string, inviteR
 
 // AcceptInvite accepts an invite.
 func (s *UserService) AcceptInvite(ctx context.Context, acceptInviteRequest *AcceptInviteRequest) (*http.Response, error) {
-	path := "api/xcr/v2/users/invites"
+	path := "api/xcr/v3/invites"
 	_, resp, err := s.client.post(ctx, path, new(emptyResponse), acceptInviteRequest)
 	if err != nil {
 		return resp, err
@@ -76,9 +78,9 @@ func (s *UserService) AcceptInvite(ctx context.Context, acceptInviteRequest *Acc
 	return resp, nil
 }
 
-// ResendInvite resends an invite to the given email address.
-func (s *UserService) ResendInvite(ctx context.Context, email string) (*http.Response, error) {
-	path := fmt.Sprintf("api/xcr/v2/invites/%v", email)
+// ResendInvite resends the given invite.
+func (s *UserService) ResendInvite(ctx context.Context, id int) (*http.Response, error) {
+	path := fmt.Sprintf("api/xcr/v3/invites/%v", id)
 	_, resp, err := s.client.put(ctx, path, new(emptyResponse), struct{}{})
 	if err != nil {
 		return resp, err
@@ -87,10 +89,10 @@ func (s *UserService) ResendInvite(ctx context.Context, email string) (*http.Res
 	return resp, nil
 }
 
-// DeleteInvite deletes an invite to the given email address.
-func (s *UserService) DeleteInvite(ctx context.Context, email string) (*http.Response, error) {
-	path := fmt.Sprintf("api/xcr/v2/invites/%v", email)
-	resp, err := s.client.delete(ctx, path)
+// DeleteInvite deletes the given invite
+func (s *UserService) DeleteInvite(ctx context.Context, id int) (*http.Response, error) {
+	path := fmt.Sprintf("api/xcr/v3/invites/%v", id)
+	resp, err := s.client.delete(ctx, path, url.Values{})
 	if err != nil {
 		return resp, err
 	}

--- a/enf/user_invite_test.go
+++ b/enf/user_invite_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 )
 
-func TestUserService_ListInvitesForDomainAddress(t *testing.T) {
-	path := "/api/xcr/v2/domains/1/invites"
+func TestUserService_ListInvites(t *testing.T) {
+	path := "/api/xcr/v3/invites"
 
 	responseBodyMock := `{
 		"data": [
@@ -30,7 +30,7 @@ func TestUserService_ListInvitesForDomainAddress(t *testing.T) {
 	}
 
 	method := func(client *Client) (interface{}, *http.Response, error) {
-		return client.User.ListInvitesForDomainAddress(context.Background(), "1")
+		return client.User.ListInvites(context.Background())
 	}
 
 	testParams := &TestParams{
@@ -45,13 +45,18 @@ func TestUserService_ListInvitesForDomainAddress(t *testing.T) {
 	getTest(testParams)
 }
 
-func TestUserService_SendNewInvite(t *testing.T) {
-	path := "/api/xcr/v2/domains/1/invites"
+func TestUserService_SendInvite(t *testing.T) {
+	path := "/api/xcr/v3/invites"
 
 	requestBody := &SendInviteRequest{
 		Email:    String("user@acme.com"),
 		FullName: String("Xaptum User"),
-		UserType: String("DOMAIN_USER"),
+		Roles: []*UserRole{
+			{
+				CIDR: String("D/d0"),
+				Role: String("DOMAIN_USER"),
+			},
+		},
 	}
 
 	responseBodyMock := `{
@@ -60,7 +65,10 @@ func TestUserService_SendNewInvite(t *testing.T) {
 				"id": 1,
 				"email": "user@acme.com",
 				"name": "Xaptum User",
-				"type": "DOMAIN_USER"
+				"role": {
+					"cidr" : "D/d0",
+					"role" : "DOMAIN_USER"
+				}
 			}
 		]
 	}`
@@ -69,11 +77,14 @@ func TestUserService_SendNewInvite(t *testing.T) {
 		ID:    Int(1),
 		Email: String("user@acme.com"),
 		Name:  String("Xaptum User"),
-		Type:  String("DOMAIN_USER"),
+		Role: &UserRole{
+			CIDR: String("D/d0"),
+			Role: String("DOMAIN_USER"),
+		},
 	}
 
 	method := func(client *Client) (interface{}, *http.Response, error) {
-		return client.User.SendNewInvite(context.Background(), "1", requestBody)
+		return client.User.SendInvite(context.Background(), requestBody)
 	}
 
 	testParams := &TestParams{
@@ -89,7 +100,7 @@ func TestUserService_SendNewInvite(t *testing.T) {
 }
 
 func TestUserService_AcceptInvite(t *testing.T) {
-	path := "/api/xcr/v2/users/invites"
+	path := "/api/xcr/v3/invites"
 
 	requestBody := &AcceptInviteRequest{
 		Email:    String("user@acme.com"),
@@ -117,12 +128,12 @@ func TestUserService_AcceptInvite(t *testing.T) {
 }
 
 func TestUserService_ResendInvite(t *testing.T) {
-	path := "/api/xcr/v2/invites/user@acme.com"
+	path := "/api/xcr/v3/invites/1"
 
 	responseBodyMock := `[]`
 
 	method := func(client *Client) (interface{}, *http.Response, error) {
-		resp, err := client.User.ResendInvite(context.Background(), "user@acme.com")
+		resp, err := client.User.ResendInvite(context.Background(), 1)
 		return struct{}{}, resp, err
 	}
 
@@ -139,12 +150,12 @@ func TestUserService_ResendInvite(t *testing.T) {
 }
 
 func TestUserService_DeleteInvite(t *testing.T) {
-	path := "/api/xcr/v2/invites/user@acme.com"
+	path := "/api/xcr/v3/invites/1"
 
 	responseBodyMock := `[]`
 
 	method := func(client *Client) (interface{}, *http.Response, error) {
-		resp, err := client.User.DeleteInvite(context.Background(), "user@acme.com")
+		resp, err := client.User.DeleteInvite(context.Background(), 1)
 		return struct{}{}, resp, err
 	}
 

--- a/enf/user_role.go
+++ b/enf/user_role.go
@@ -1,0 +1,90 @@
+package enf
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// UserRole represents an ENF user role.
+type UserRole struct {
+	CIDR *string `json:"cidr"`
+	Role *string `json:"role"`
+}
+
+// DeleteUserRolesQuery represents the query parameters to delete some
+// of a user's roles.
+type DeleteUserRolesQuery struct {
+	roles   []string
+	network *string
+}
+
+type userRoleResponse struct {
+	Data []*UserRole            `json:"data"`
+	Page map[string]interface{} `json:"page"`
+}
+
+// ListUserRoles get the list of roles for the given user.
+func (s *UserService) ListUserRoles(ctx context.Context, userID int) ([]*UserRole, *http.Response, error) {
+	path := fmt.Sprintf("api/xcr/v3/users/%v/roles", userID)
+	body, resp, err := s.client.get(ctx, path, url.Values{}, new(userRoleResponse))
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return body.(*userRoleResponse).Data, resp, nil
+}
+
+// AppendUserRoles adds roles to the user
+func (s *UserService) AppendUserRoles(ctx context.Context, userID int, roles []UserRole) ([]*UserRole, *http.Response, error) {
+	path := fmt.Sprintf("api/xcr/v3/users/%v/roles", userID)
+	body, resp, err := s.client.post(ctx, path, new(userRoleResponse), roles)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return body.(*userRoleResponse).Data, resp, nil
+}
+
+// ReplaceUserRoles replaces all roles for the user
+func (s *UserService) ReplaceUserRoles(ctx context.Context, userID int, roles []UserRole) ([]*UserRole, *http.Response, error) {
+	path := fmt.Sprintf("api/xcr/v3/users/%v/roles", userID)
+	body, resp, err := s.client.put(ctx, path, new(userRoleResponse), roles)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return body.(*userRoleResponse).Data, resp, nil
+}
+
+// DeleteUserRolesQuery deletes the roles for given user that match the specified query
+func (s *UserService) DeleteUserRolesWithQuery(ctx context.Context, userID int, query DeleteUserRolesQuery) (*http.Response, error) {
+	path := fmt.Sprintf("api/xcr/v3/users/%v/roles", userID)
+
+	queryParameters := url.Values{}
+	queryParameters.Add("roles", strings.Join(query.roles, ","))
+	if query.network != nil {
+		queryParameters.Add("network_cidr", *query.network)
+	}
+
+	resp, err := s.client.delete(ctx, path, queryParameters)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// DeleteUserRoles deletes all roles from the given user
+func (s *UserService) DeleteUserRoles(ctx context.Context, userID int) (*http.Response, error) {
+	path := fmt.Sprintf("api/xcr/v3/users/%v/roles", userID)
+
+	resp, err := s.client.delete(ctx, path, url.Values{})
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}

--- a/enf/user_role_test.go
+++ b/enf/user_role_test.go
@@ -1,0 +1,191 @@
+package enf
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestUserService_ListUserRoles(t *testing.T) {
+	path := "/api/xcr/v3/users/1/roles"
+
+	responseBodyMock := `{
+		"data": [
+			{
+				"cidr": "D/d0",
+				"role": "DOMAIN_ADMIN"
+			},
+			{
+				"cidr": "N/n0",
+				"role": "NETWORK_USER"
+			}
+		]
+	}`
+
+	expected := []*UserRole{
+		{
+			CIDR: String("D/d0"),
+			Role: String("DOMAIN_ADMIN"),
+		},
+		{
+			CIDR: String("N/n0"),
+			Role: String("NETWORK_USER"),
+		},
+	}
+
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		return client.User.ListUserRoles(context.Background(), 1)
+	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      struct{}{},
+		ResponseBodyMock: responseBodyMock,
+		Expected:         expected,
+		Method:           method,
+		T:                t,
+	}
+
+	getTest(testParams)
+}
+
+func TestUserService_AppendUserRoles(t *testing.T) {
+	path := "/api/xcr/v3/users/1/roles"
+
+	requestBody := []UserRole{
+		{String("N/n0"), String("NETWORK_USER")},
+	}
+
+	responseBodyMock := `{
+		"data": [
+			{
+				"cidr": "D/d0",
+				"role": "DOMAIN_ADMIN"
+			},
+			{
+				"cidr": "N/n0",
+				"role": "NETWORK_USER"
+			}
+		]
+	}`
+
+	expected := []*UserRole{
+		{
+			CIDR: String("D/d0"),
+			Role: String("DOMAIN_ADMIN"),
+		},
+		{
+			CIDR: String("N/n0"),
+			Role: String("NETWORK_USER"),
+		},
+	}
+
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		return client.User.AppendUserRoles(context.Background(), 1, requestBody)
+	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      requestBody,
+		ResponseBodyMock: responseBodyMock,
+		Expected:         expected,
+		Method:           method,
+		T:                t,
+	}
+
+	postTest(testParams)
+}
+
+func TestUserService_ReplaceUserRoles(t *testing.T) {
+	path := "/api/xcr/v3/users/1/roles"
+
+	requestBody := []UserRole{
+		{String("D/d0"), String("DOMAIN_ADMIN")},
+		{String("N/n0"), String("NETWORK_USER")},
+	}
+
+	responseBodyMock := `{
+		"data": [
+			{
+				"cidr": "D/d0",
+				"role": "DOMAIN_ADMIN"
+			},
+			{
+				"cidr": "N/n0",
+				"role": "NETWORK_USER"
+			}
+		]
+	}`
+
+	expected := []*UserRole{
+		{
+			CIDR: String("D/d0"),
+			Role: String("DOMAIN_ADMIN"),
+		},
+		{
+			CIDR: String("N/n0"),
+			Role: String("NETWORK_USER"),
+		},
+	}
+
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		return client.User.ReplaceUserRoles(context.Background(), 1, requestBody)
+	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      requestBody,
+		ResponseBodyMock: responseBodyMock,
+		Expected:         expected,
+		Method:           method,
+		T:                t,
+	}
+
+	putTest(testParams)
+}
+
+func TestUserService_DeleteUserRoles(t *testing.T) {
+	path := "/api/xcr/v3/users/1/roles"
+
+	responseBodyMock := `[]`
+
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		resp, err := client.User.DeleteUserRoles(context.Background(), 1)
+		return struct{}{}, resp, err
+	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      struct{}{},
+		ResponseBodyMock: responseBodyMock,
+		Expected:         struct{}{},
+		Method:           method,
+		T:                t,
+	}
+
+	deleteTest(testParams)
+}
+
+func TestUserService_DeleteUserRolesWithQuery(t *testing.T) {
+	path := "/api/xcr/v3/users/1/roles"
+
+	responseBodyMock := `[]`
+
+	query := DeleteUserRolesQuery{[]string{"DOMAIN_*", "*_ADMIN"}, nil}
+
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		resp, err := client.User.DeleteUserRolesWithQuery(context.Background(), 1, query)
+		return struct{}{}, resp, err
+	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      struct{}{},
+		ResponseBodyMock: responseBodyMock,
+		Expected:         struct{}{},
+		Method:           method,
+		T:                t,
+	}
+
+	deleteTest(testParams)
+}

--- a/enf/user_test.go
+++ b/enf/user_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 )
 
-func TestUserService_ListUsersForDomainAddress(t *testing.T) {
-	path := "/api/xcr/v2/domains/N/users"
+func TestUserService_ListUsers(t *testing.T) {
+	path := "/api/xcr/v3/users"
 
 	responseBodyMock := `{
 		"data": [
@@ -15,6 +15,12 @@ func TestUserService_ListUsersForDomainAddress(t *testing.T) {
 				"user_id": 1,
 				"username": "user@acme",
 				"full_name": "Xaptum User",
+				"roles": [
+					{
+						"role" : "DOMAIN_USER",
+						"cidr" : "D/d0"
+					}
+				],
 				"status": "ACTIVE"
 			}
 		]
@@ -25,12 +31,18 @@ func TestUserService_ListUsersForDomainAddress(t *testing.T) {
 			UserID:   Int(1),
 			Username: String("user@acme"),
 			FullName: String("Xaptum User"),
-			Status:   String("ACTIVE"),
+			Roles: []*UserRole{
+				{
+					Role: String("DOMAIN_USER"),
+					CIDR: String("D/d0"),
+				},
+			},
+			Status: String("ACTIVE"),
 		},
 	}
 
 	method := func(client *Client) (interface{}, *http.Response, error) {
-		return client.User.ListUsersForDomainAddress(context.Background(), "N")
+		return client.User.ListUsers(context.Background())
 	}
 
 	testParams := &TestParams{
@@ -45,8 +57,8 @@ func TestUserService_ListUsersForDomainAddress(t *testing.T) {
 	getTest(testParams)
 }
 
-func TestUserService_ListUsersForDomainID(t *testing.T) {
-	path := "/api/xcr/v2/domains/1/users"
+func TestUserService_ListUsersForDomain(t *testing.T) {
+	path := "/api/xcr/v3/users"
 
 	responseBodyMock := `{
 		"data": [
@@ -54,6 +66,12 @@ func TestUserService_ListUsersForDomainID(t *testing.T) {
 				"user_id": 1,
 				"username": "user@acme",
 				"full_name": "Xaptum User",
+				"roles": [
+					{
+						"role" : "DOMAIN_USER",
+						"cidr" : "D/d0"
+					}
+				],
 				"status": "ACTIVE"
 			}
 		]
@@ -64,12 +82,126 @@ func TestUserService_ListUsersForDomainID(t *testing.T) {
 			UserID:   Int(1),
 			Username: String("user@acme"),
 			FullName: String("Xaptum User"),
-			Status:   String("ACTIVE"),
+			Roles: []*UserRole{
+				{
+					Role: String("DOMAIN_USER"),
+					CIDR: String("D/d0"),
+				},
+			},
+			Status: String("ACTIVE"),
 		},
 	}
 
 	method := func(client *Client) (interface{}, *http.Response, error) {
-		return client.User.ListUsersForDomainID(context.Background(), "1")
+		return client.User.ListUsersForDomain(context.Background(), "D/d0")
+	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      struct{}{},
+		ResponseBodyMock: responseBodyMock,
+		Expected:         expected,
+		Method:           method,
+		T:                t,
+	}
+
+	getTest(testParams)
+}
+
+func TestUserService_ListUsersForNetwork(t *testing.T) {
+	path := "/api/xcr/v3/users"
+
+	responseBodyMock := `{
+		"data": [
+			{
+				"user_id": 1,
+				"username": "user@acme",
+				"full_name": "Xaptum User",
+				"roles": [
+					{
+						"role" : "NETWORK_ADMIN",
+						"cidr" : "N/n0"
+					}
+				],
+				"status": "ACTIVE"
+			}
+		]
+	}`
+
+	expected := []*User{
+		{
+			UserID:   Int(1),
+			Username: String("user@acme"),
+			FullName: String("Xaptum User"),
+			Roles: []*UserRole{
+				{
+					Role: String("NETWORK_ADMIN"),
+					CIDR: String("N/n0"),
+				},
+			},
+			Status: String("ACTIVE"),
+		},
+	}
+
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		return client.User.ListUsersForNetwork(context.Background(), "N/n0")
+	}
+
+	testParams := &TestParams{
+		Path:             path,
+		RequestBody:      struct{}{},
+		ResponseBodyMock: responseBodyMock,
+		Expected:         expected,
+		Method:           method,
+		T:                t,
+	}
+
+	getTest(testParams)
+}
+
+func TestUserService_GetUser(t *testing.T) {
+	path := "/api/xcr/v3/users/1"
+
+	responseBodyMock := `{
+		"data": [
+			{
+				"user_id": 1,
+				"username": "user@acme",
+				"full_name": "Xaptum User",
+				"roles": [
+					{
+						"role" : "DOMAIN_USER",
+						"cidr" : "D/d0"
+					},
+					{
+						"role" : "NETWORK_ADMIN",
+						"cidr" : "N/n0"
+					}
+				],
+				"status": "ACTIVE"
+			}
+		]
+	}`
+
+	expected := &User{
+		UserID:   Int(1),
+		Username: String("user@acme"),
+		FullName: String("Xaptum User"),
+		Roles: []*UserRole{
+			{
+				Role: String("DOMAIN_USER"),
+				CIDR: String("D/d0"),
+			},
+			{
+				Role: String("NETWORK_ADMIN"),
+				CIDR: String("N/n0"),
+			},
+		},
+		Status: String("ACTIVE"),
+	}
+
+	method := func(client *Client) (interface{}, *http.Response, error) {
+		return client.User.GetUser(context.Background(), 1)
 	}
 
 	testParams := &TestParams{
@@ -85,7 +217,7 @@ func TestUserService_ListUsersForDomainID(t *testing.T) {
 }
 
 func TestUserService_UpdateUserStatus(t *testing.T) {
-	path := "/api/xcr/v2/users/61/status"
+	path := "/api/xcr/v3/users/61/status"
 
 	requestBody := &UpdateUserStatusRequest{
 		Status: String("INACTIVE"),
@@ -111,7 +243,7 @@ func TestUserService_UpdateUserStatus(t *testing.T) {
 }
 
 func TestUserService_EmailResetPasswordCode(t *testing.T) {
-	path := "/api/xcr/v2/users/reset"
+	path := "/api/xcr/v3/users/reset"
 
 	responseBodyMock := `[]`
 
@@ -133,7 +265,7 @@ func TestUserService_EmailResetPasswordCode(t *testing.T) {
 }
 
 func TestUserService_ResetPassword(t *testing.T) {
-	path := "/api/xcr/v2/users/reset"
+	path := "/api/xcr/v3/users/reset"
 
 	requestBody := &ResetPasswordRequest{
 		Email:    String("user@acme.com"),


### PR DESCRIPTION
This PR updates the user resource to API v3
- adds the user role resource
- move the user resource paths out from /domain into /users
- in the user resource, replaces type with role
- moves the invite resource paths out from /domain or /users into /invites
- in the invite resource, replaces type with role

